### PR TITLE
Update plugin id to match npm id

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "App Security API plugin",
   "cordova": {
-    "id": "com-intel-security",
+    "id": "com-intel-security-cordova-plugin",
     "platforms": [
       "android",
       "ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"    
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com-intel-security"
+    id="com-intel-security-cordova-plugin"
     version="2.0.0">
     <name>APP Security API</name>
     <description>App Security API plugin</description>


### PR DESCRIPTION
Since version 2.0.0 plugin id in `plugin.xml` and npm package id in `package.json` have been diverged, This causes issues with plugin installation/uninstallation when plugin is being restored from `config.xml` or if there is a dependency taken on this plugin by another one.

*Repro steps:*
- create new empty app

  `cordova create foo && cd foo`
- add plugin entry to `config.xml`:

  `<plugin name="com-intel-security-cordova-plugin" />`
- add any platform to the app

  `cordova platform add android`

  Note - this will install saved plugin
- prepare the project

  `cordova prepare`

*Expected:* cordova won't try to restore saved plugin as it is already installed

*Actual:* cordova tries to restore the plugin because it has been installed as `com-intel-security`
```
λ cordova prepare -d
Checking config.xml for saved plugins that haven't been added to the project
Discovered plugin "com-intel-security-cordova-plugin" in config.xml. Adding it to the project
...
Calling plugman.fetch on plugin "com-intel-security-cordova-plugin"
Fetching plugin "com-intel-security-cordova-plugin" via npm
Copying plugin "C:\Users\kotik\AppData\Roaming\npm-cache\com-intel-security-cordova-plugin\2.0.0\package" => "d:\PROJECTS\Temp\test-security\plugins\com-intel-security"
Calling plugman.install on plugin "d:\PROJECTS\Temp\test-security\plugins\com-intel-security" for platform "android
Plugin "com-intel-security" already installed on android.
...
```

The proposed solution is to update id in `plugin.xml` to match npm package id.