### PR TITLE
Use default output path for build

### DIFF
--- a/src/windows/ChooseArch_Windows.js
+++ b/src/windows/ChooseArch_Windows.js
@@ -163,9 +163,6 @@ function fixProjectFile81(fileName) {
                     "\n\t</ItemGroup>" +
                     "\n</Project>"
                 );
-                newData = newData.replace("<OutputPath>build\\windows",
-                    "<OutputPath>build\\windows81"
-                );
                 fs.writeFileSync(fileName, newData);
             }
         });
@@ -198,9 +195,6 @@ function fixProjectFile10(fileName) {
                     "\n\t\t<SDKReference Include=\"Microsoft.VCLibs, Version=14.0\" />" +
                     "\n\t</ItemGroup>" +
                     "\n</Project>"
-                );
-                newData = newData.replace("<OutputPath>build\\windows",
-                    "<OutputPath>build\\windows10"
                 );
                 fs.writeFileSync(fileName, newData);
             }


### PR DESCRIPTION
This change fixes application deployment failure in VS 15 Preview, which complains on missing apprecipe file.  In fact appxrecipe is being produced but then placed into non-default directory, which causes VS to fail with the following error
```
Checking for: ...\BlankCordovaApp4\BlankCordovaApp4\bin\Windows-x86\Debug\CordovaApp.Windows10.build.appxrecipe
...
Could not locate the appxrecipe file. You may need to build your project.
```